### PR TITLE
Add filtering and sorting to ANT viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,18 @@
       tr:nth-child(even) {
         background-color: rgba(28, 27, 83, 0.1);
       }
+      #filterBar input,
+      #filterBar select {
+        padding: 0.5rem;
+        font-family: inherit;
+        border: 1px solid var(--border-color);
+        background-color: #191919;
+        color: var(--text-color);
+        border-radius: 4px;
+      }
+      #recordCount {
+        color: var(--text-secondary);
+      }
     </style>
   </head>
   <body>
@@ -121,6 +133,18 @@
     </div>
     
     <p id="status" class="loading">Loading ANT records...</p>
+    <div id="filterBar" style="display:flex;align-items:center;gap:0.5rem;margin-top:0.5rem;">
+      <label for="filterInput">Filter:</label>
+      <input type="text" id="filterInput" placeholder="Type to filter" style="flex:1;min-width:150px;"/>
+      <label for="filterField">Filter By:</label>
+      <select id="filterField">
+        <option value="under_name">Under_name</option>
+        <option value="txid">Transaction ID</option>
+        <option value="ttl">TTL</option>
+        <option value="all">All</option>
+      </select>
+      <span id="recordCount" style="margin-left:auto;"></span>
+    </div>
     <div id="records"></div>
     <script type="module" src="/main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -5,6 +5,12 @@ import { connect } from "@permaweb/aoconnect";
 const DEFAULT_CU_URL = "https://cu.ardrive.io";
 const DEFAULT_GATEWAY_URL = "https://arweave.net"; // Using SDK defaults
 
+let originalRecords = [];
+let currentFilterText = "";
+let currentFilterField = "under_name";
+let currentSortField = null;
+let currentSortDir = null;
+
 // Function to get ArNS name from hostname or use fallback
 function getArNsNameFromHostname() {
   const hostname = window.location.hostname; // e.g., "my.page.site"
@@ -30,6 +36,150 @@ function getGatewayUrlFromHostname() {
   return parts.slice(1).join(".");
 }
 
+function applyFilter(records) {
+  if (!currentFilterText) return records;
+  const t = currentFilterText.toLowerCase();
+  return records.filter((r) => {
+    const under = r.under_name.toLowerCase();
+    const tx = r.transactionId.toLowerCase();
+    const ttl = String(r.ttlSeconds).toLowerCase();
+    switch (currentFilterField) {
+      case "under_name":
+        return under.includes(t);
+      case "txid":
+        return tx.includes(t);
+      case "ttl":
+        return ttl.includes(t);
+      case "all":
+        return under.includes(t) || tx.includes(t) || ttl.includes(t);
+      default:
+        return true;
+    }
+  });
+}
+
+function sortRecords(records) {
+  if (!currentSortField) return [...records];
+  const sorted = [...records].sort((a, b) => {
+    let av = a[currentSortField];
+    let bv = b[currentSortField];
+    if (currentSortField === "ttlSeconds") {
+      av = Number(av);
+      bv = Number(bv);
+    } else {
+      av = String(av).toLowerCase();
+      bv = String(bv).toLowerCase();
+    }
+    if (av > bv) return 1;
+    if (av < bv) return -1;
+    return 0;
+  });
+  return currentSortDir === "desc" ? sorted.reverse() : sorted;
+}
+
+function updateRecordCount(total, shown) {
+  const countEl = document.getElementById("recordCount");
+  if (!countEl) return;
+  let text = `Total Records: ${total}`;
+  if (currentFilterText) {
+    text += ` (${shown} shown)`;
+  }
+  countEl.textContent = text;
+}
+
+function getSortIndicator(field) {
+  if (currentSortField !== field) return "";
+  return currentSortDir === "desc" ? " \u25BC" : " \u25B2"; // ▼ or ▲
+}
+
+function buildTable(recordsEl) {
+  const table = document.createElement("table");
+  const headerRow = document.createElement("tr");
+  headerRow.innerHTML =
+    `<th data-field="under_name">Under_name${getSortIndicator("under_name")}</th>` +
+    `<th data-field="transactionId">Transaction ID${getSortIndicator("transactionId")}</th>` +
+    `<th>Click to Copy</th>` +
+    `<th data-field="ttlSeconds">TTL Secs${getSortIndicator("ttlSeconds")}</th>`;
+  table.appendChild(headerRow);
+
+  headerRow.querySelectorAll("th[data-field]").forEach((th) => {
+    th.style.cursor = "pointer";
+    th.addEventListener("click", () => {
+      const field = th.dataset.field;
+      if (currentSortField === field) {
+        if (currentSortDir === "asc") currentSortDir = "desc";
+        else if (currentSortDir === "desc") {
+          currentSortField = null;
+          currentSortDir = null;
+        } else currentSortDir = "asc";
+      } else {
+        currentSortField = field;
+        currentSortDir = "asc";
+      }
+      renderTable();
+    });
+  });
+
+  const displayRecords = applyFilter(sortRecords(originalRecords));
+  updateRecordCount(originalRecords.length, displayRecords.length);
+
+  if (displayRecords.length === 0) {
+    recordsEl.appendChild(table);
+    return;
+  }
+
+  for (const rec of displayRecords) {
+    const row = document.createElement("tr");
+
+    const underLink = document.createElement("a");
+    underLink.href = rec.href;
+    underLink.textContent = rec.under_name;
+    underLink.style.wordBreak = "break-all";
+    underLink.target = "_blank";
+    underLink.rel = "noopener noreferrer";
+
+    const txLink = document.createElement("a");
+    txLink.href = rec.txHref;
+    txLink.textContent = rec.transactionId;
+    txLink.style.wordBreak = "break-all";
+    txLink.target = "_blank";
+    txLink.rel = "noopener noreferrer";
+
+    const copyBtn = document.createElement("button");
+    copyBtn.textContent = "📋";
+    copyBtn.title = "Copy Transaction ID";
+    copyBtn.style.cursor = "pointer";
+    copyBtn.style.display = "block";
+    copyBtn.style.margin = "0 auto";
+    copyBtn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(rec.transactionId);
+        copyBtn.textContent = "✅";
+        setTimeout(() => (copyBtn.textContent = "📋"), 1000);
+      } catch {
+        copyBtn.textContent = "❌";
+        setTimeout(() => (copyBtn.textContent = "📋"), 1000);
+      }
+    });
+
+    row.innerHTML = `<td></td><td></td><td></td>`;
+    row.children[0].appendChild(underLink);
+    row.children[1].appendChild(txLink);
+    row.children[2].appendChild(copyBtn);
+    row.innerHTML += `<td>${rec.ttlSeconds}</td>`;
+
+    table.appendChild(row);
+  }
+
+  recordsEl.appendChild(table);
+}
+
+function renderTable() {
+  const recordsEl = document.getElementById("records");
+  recordsEl.innerHTML = "";
+  buildTable(recordsEl);
+}
+
 // Main function to fetch and display ANT records
 async function fetchAndDisplayRecords(arnsName, gatewayUrl, cuUrl, protocol) {
   const statusEl = document.getElementById("status");
@@ -43,29 +193,30 @@ async function fetchAndDisplayRecords(arnsName, gatewayUrl, cuUrl, protocol) {
   try {
     // Initialize the ar.io SDK with optional gateway override
     gatewayUrl = gatewayUrl ? gatewayUrl : DEFAULT_GATEWAY_URL;
-    
+
     // Ensure gatewayUrl includes protocol
     let fullGatewayUrl = gatewayUrl;
     if (!/^https?:\/\//i.test(gatewayUrl)) {
       fullGatewayUrl = `${window.location.protocol}//${gatewayUrl}`;
     }
-    
+
     const ario = ARIO.mainnet({
       process: new AOProcess({
         processId: ARIO_MAINNET_PROCESS_ID,
         ao: connect({
-          MODE: 'legacy',
+          MODE: "legacy",
           CU_URL: cuUrl || DEFAULT_CU_URL,
           GRAPHQL_URL: `${gatewayUrl}/graphql`,
           GATEWAY_URL: gatewayUrl,
-        })
-      })
+        }),
+      }),
     });
     const record = await ario.getArNSRecord({ name: arnsName });
     console.log(`ArNS Record: ${JSON.stringify(record, null, 2)}`);
 
     if (!record || !record.processId) {
       statusEl.textContent = `No ANT found for ArNS name "${arnsName}".`;
+      updateRecordCount(0, 0);
       return;
     }
 
@@ -73,75 +224,31 @@ async function fetchAndDisplayRecords(arnsName, gatewayUrl, cuUrl, protocol) {
       process: new AOProcess({
         processId: record.processId,
         ao: connect({
-          MODE: 'legacy',
+          MODE: "legacy",
           CU_URL: cuUrl || DEFAULT_CU_URL,
           GRAPHQL_URL: `${gatewayUrl}/graphql`,
           GATEWAY_URL: gatewayUrl,
         }),
       }),
     });
-    
+
     const antRecords = await ant.getRecords();
     console.log(`ANT Records: ${JSON.stringify(antRecords, null, 2)}`);
 
-    // Display the ANT records
+    originalRecords = Object.entries(antRecords).map(([undername, rec]) => ({
+      under_name: undername,
+      transactionId: rec.transactionId,
+      ttlSeconds: rec.ttlSeconds,
+      href:
+        undername === "@"
+          ? `${protocol}//${arnsName}.${fullGatewayUrl.replace(`${protocol}//`, "")}`
+          : `${protocol}//${undername}_${arnsName}.${fullGatewayUrl.replace(`${protocol}//`, "")}`,
+      txHref: `${fullGatewayUrl}/${rec.transactionId}`,
+    }));
+
     statusEl.textContent = `ANT Records for "${arnsName}":`;
     statusEl.className = "";
-
-    const table = document.createElement("table");
-    const headerRow = document.createElement("tr");
-    headerRow.innerHTML =
-      "<th>Undername</th><th>Transaction ID</th><th>Click to Copy</th><th>TTL Secs</th>";
-    table.appendChild(headerRow);
-
-    for (const [undername, antRecord] of Object.entries(antRecords)) {
-      const row = document.createElement("tr");
-
-      // Create undername link
-      const undernameLink = document.createElement("a");
-      console.log(`Full gateway url: ${fullGatewayUrl}; Protocol: ${protocol}; Undername: ${undername}; ArNS Name: ${arnsName}`);
-      undernameLink.href = undername === "@" ? `${protocol}//${arnsName}.${fullGatewayUrl.replace(`${protocol}//`, "")}` : `${protocol}//${undername}_${arnsName}.${fullGatewayUrl.replace(`${protocol}//`, "")}`;
-      undernameLink.textContent = undername;
-      undernameLink.style.wordBreak = "break-all";
-      undernameLink.target = "_blank";
-      undernameLink.rel = "noopener noreferrer";
-
-      // Create clickable transactionId link
-      const txLink = document.createElement("a");
-      txLink.href = `${fullGatewayUrl}/${antRecord.transactionId}`;
-      txLink.textContent = antRecord.transactionId;
-      txLink.style.wordBreak = "break-all";
-      txLink.target = "_blank";
-      txLink.rel = "noopener noreferrer";
-
-      // Create copy emoji button
-      const copyBtn = document.createElement("button");
-      copyBtn.textContent = "📋";
-      copyBtn.title = "Copy Transaction ID";
-      copyBtn.style.cursor = "pointer";
-      copyBtn.style.display = "block";
-      copyBtn.style.margin = "0 auto";
-      copyBtn.onclick = async () => {
-        try {
-          await navigator.clipboard.writeText(antRecord.transactionId);
-          copyBtn.textContent = "✅";
-          setTimeout(() => (copyBtn.textContent = "📋"), 1000);
-        } catch {
-          copyBtn.textContent = "❌";
-          setTimeout(() => (copyBtn.textContent = "📋"), 1000);
-        }
-      };
-
-      row.innerHTML = `<td></td><td></td><td></td>`;
-      row.children[0].appendChild(undernameLink);
-      row.children[1].appendChild(txLink);
-      row.children[2].appendChild(copyBtn);
-      row.innerHTML += `<td>${antRecord.ttlSeconds}</td>`;
-
-      table.appendChild(row);
-    }
-
-    recordsEl.appendChild(table);
+    renderTable();
   } catch (error) {
     console.error(error);
     statusEl.textContent = "Error loading ANT records.";
@@ -161,6 +268,10 @@ function initialize() {
   const cuUrlInput = document.getElementById("cuUrl");
   const applyButton = document.getElementById("applySettings");
   const restoreDefaultsButton = document.getElementById("restoreDefaults");
+  const filterInput = document.getElementById("filterInput");
+  const filterFieldSelect = document.getElementById("filterField");
+
+  updateRecordCount(0, 0);
   
   // Set initial value for ArNS name
   arnsNameInput.value = defaultArnsName;
@@ -183,6 +294,16 @@ function initialize() {
       cuUrlInput.value.trim() || null,
       newProtocol,
     );
+  });
+
+  filterInput.addEventListener("input", () => {
+    currentFilterText = filterInput.value;
+    renderTable();
+  });
+
+  filterFieldSelect.addEventListener("change", () => {
+    currentFilterField = filterFieldSelect.value;
+    renderTable();
   });
   
   // Restore defaults button handler


### PR DESCRIPTION
## Summary
- add filter input and filter dropdown
- show total and filtered record counts
- implement sort indicators and sorting by columns
- replace `Undername` with `Under_name`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684887bb330c832da38ea214c01c32fa